### PR TITLE
Make Cell.Grid mandatory

### DIFF
--- a/SideView.BlazorGL.Tests/Application/TileMap/Neighbor/NeighborFinderTest.cs
+++ b/SideView.BlazorGL.Tests/Application/TileMap/Neighbor/NeighborFinderTest.cs
@@ -15,9 +15,10 @@ public class NeighborFinderTest
     public void TestFindNeighborsReturnsEmptyCollectionIfOnlyOneCell()
     {
         var finder = new NeighborFinder();
-        var cell = new Cell(0, 0, CellType.Empty);
-
-        var neighbors = finder.FindNeighbors(cell, false, GetDistance);
+        var grid = new Grid(new[,] { { ' ' } });
+        var cell = grid[0, 0];
+        
+        var neighbors = finder.FindNeighbors(cell!, false, GetDistance);
         var cellCostPairs = neighbors.ToArray();
 
         Assert.That(cellCostPairs, Is.Empty);
@@ -36,14 +37,14 @@ public class NeighborFinderTest
 
     public static IEnumerable<object> GridNeighborNoJumpingProvider()
     {
-        var grid = Grid.CreateFromArray(new[,] {
+        var grid = new Grid(new[,] {
             { ' ', ' ', ' ' },
             { ' ', ' ', ' ' },
             { ' ', ' ', ' ' }
         });
         yield return new object[] { grid, grid[1, 1]!, new[] { new CellCostPair(grid[1, 2]!, 1) } };
 
-        grid = Grid.CreateFromArray(new[,] {
+        grid = new Grid(new[,] {
             { ' ', ' ', ' ' },
             { ' ', ' ', ' ' },
             { ' ', 'B', ' ' }
@@ -57,7 +58,7 @@ public class NeighborFinderTest
             }
         };
 
-        grid = Grid.CreateFromArray(new[,] {
+        grid = new Grid(new[,] {
             { ' ', 'L', ' ' },
             { ' ', 'L', ' ' },
             { ' ', 'L', ' ' }
@@ -73,7 +74,7 @@ public class NeighborFinderTest
             }
         };
 
-        grid = Grid.CreateFromArray(new[,] {
+        grid = new Grid(new[,] {
             { 'B', 'B', 'B' },
             { 'H', 'H', 'H' },
             { ' ', ' ', ' ' }
@@ -102,7 +103,7 @@ public class NeighborFinderTest
 
     public static IEnumerable<object> GridNeighborProvider()
     {
-        var grid = Grid.CreateFromArray(new[,] {
+        var grid = new Grid(new[,] {
             { ' ', ' ', ' ' , ' ', ' ' },
             { ' ', ' ', 'B' , ' ', ' ' },
             { ' ', ' ', 'B' , ' ', ' ' },
@@ -124,7 +125,7 @@ public class NeighborFinderTest
             }
         };
 
-        grid = Grid.CreateFromArray(new[,] {
+        grid = new Grid(new[,] {
             { ' ', ' ', ' ' , ' ', ' ' },
             { ' ', ' ', 'B' , 'B', 'B' },
             { ' ', ' ', ' ' , ' ', ' ' },
@@ -144,7 +145,7 @@ public class NeighborFinderTest
             }
         };
 
-        grid = Grid.CreateFromArray(new[,] {
+        grid = new Grid(new[,] {
             { ' ', ' ', ' ' , ' ', ' ' },
             { ' ', ' ', ' ' , ' ', ' ' },
             { ' ', ' ', ' ' , ' ', ' ' },

--- a/SideView.BlazorGL.Tests/Application/TileMap/Neighbor/NeighborFinderTest.cs
+++ b/SideView.BlazorGL.Tests/Application/TileMap/Neighbor/NeighborFinderTest.cs
@@ -17,7 +17,7 @@ public class NeighborFinderTest
         var finder = new NeighborFinder();
         var grid = new Grid(new[,] { { ' ' } });
         var cell = grid[0, 0];
-        
+
         var neighbors = finder.FindNeighbors(cell!, false, GetDistance);
         var cellCostPairs = neighbors.ToArray();
 

--- a/SideView.BlazorGL/Application/Pathfinding.cs
+++ b/SideView.BlazorGL/Application/Pathfinding.cs
@@ -42,9 +42,10 @@ public class Pathfinding
 
     public Pathfinding()
     {
-        _grid = Grid.CreateFromArray(_map);
-        _grid.StartPosition = new Point(0, 10);
-        _grid.TargetPosition = new Point(5, 1);
+        _grid = new Grid(_map) {
+            StartPosition = new Point(0, 10),
+            TargetPosition = new Point(5, 1)
+        };
         _grid.GridChanged += Reset;
 
         _gridRenderer = new GridRenderer(_grid);

--- a/SideView.BlazorGL/Application/TileMap/Cell.cs
+++ b/SideView.BlazorGL/Application/TileMap/Cell.cs
@@ -3,18 +3,10 @@ using Microsoft.Xna.Framework;
 
 namespace Pathfinding2D.SideView.BlazorGL.Application.TileMap;
 
-public class Cell(int x, int y, CellType type)
+public class Cell(int x, int y, CellType type, Grid grid)
 {
-    private Grid? _grid;
     private CellType _type = type;
 
-    internal Grid Grid {
-        set {
-            ArgumentNullException.ThrowIfNull(value);
-            if (value[X, Y] != this) throw new ArgumentException("Wrong cell.");
-            _grid = value;
-        }
-    }
     public Point Position { get; } = new(x, y);
     public int X => Position.X;
     public int Y => Position.Y;
@@ -31,7 +23,6 @@ public class Cell(int x, int y, CellType type)
     public float CostToTarget { get; set; } = float.PositiveInfinity;
     public float CostFromStart { get; set; } = float.PositiveInfinity;
     public Cell? Parent { get; set; }
-    public static Cell None { get; } = new(0, 0, CellType.Empty);
     public bool IsEmpty => Type == CellType.Empty;
     public bool IsBlock => Type == CellType.Block;
     public bool IsLadder => Type == CellType.Ladder;
@@ -48,7 +39,7 @@ public class Cell(int x, int y, CellType type)
     public Cell? DownLeft => NeighborAt(-1, 1);
     public Cell? UpRight => NeighborAt(1, -1);
     public Cell? UpLeft => NeighborAt(-1, -1);
-    public Cell? NeighborAt(int deltaX, int deltaY) => _grid?[X + deltaX, Y + deltaY];
+    public Cell? NeighborAt(int deltaX, int deltaY) => grid[X + deltaX, Y + deltaY];
 
     public event Action? CellTypeChanged;
 

--- a/SideView.BlazorGL/Application/TileMap/Grid.cs
+++ b/SideView.BlazorGL/Application/TileMap/Grid.cs
@@ -41,7 +41,7 @@ public class Grid : IEnumerable<Cell>
     public Grid(char[,] map)
     {
         if (map.Length == 0) {
-            throw new ArgumentException("map must contain at least 1 element");
+            throw new ArgumentException($"{nameof(map)} must contain at least 1 element");
         }
 
         _cells = new Cell[map.GetLength(1), map.GetLength(0)];

--- a/SideView.BlazorGL/Application/TileMap/Grid.cs
+++ b/SideView.BlazorGL/Application/TileMap/Grid.cs
@@ -38,29 +38,19 @@ public class Grid : IEnumerable<Cell>
 
     public event Action? GridChanged;
 
-    private Grid(Cell[,] cells)
-    {
-        _cells = cells;
-        foreach (var cell in this) {
-            cell.Grid = this;
-            cell.CellTypeChanged += () => GridChanged?.Invoke();
-        }
-    }
-
-    public static Grid CreateFromArray(char[,] map)
+    public Grid(char[,] map)
     {
         if (map.Length == 0) {
             throw new ArgumentException("map must contain at least 1 element");
         }
 
-        var cells = new Cell[map.GetLength(1), map.GetLength(0)];
+        _cells = new Cell[map.GetLength(1), map.GetLength(0)];
         for (var y = 0; y < map.GetLength(0); y++) {
             for (var x = 0; x < map.GetLength(1); x++) {
-                cells[x, y] = new Cell(x, y, CellTypeFromChar(map[y, x]));
+                _cells[x, y] = new Cell(x, y, CellTypeFromChar(map[y, x]), this);
+                _cells[x, y].CellTypeChanged += () => GridChanged?.Invoke();
             }
         }
-
-        return new Grid(cells);
     }
 
     private static CellType CellTypeFromChar(char c)
@@ -87,7 +77,7 @@ public class Grid : IEnumerable<Cell>
     public bool TryGetCellAtPosition(Point position, out Cell cell)
     {
         if (!IsInsideBounds(position)) {
-            cell = Cell.None;
+            cell = _cells[0, 0];
             return false;
         }
 

--- a/SideView.BlazorGL/Application/TileMapEditor/GridInputContext.cs
+++ b/SideView.BlazorGL/Application/TileMapEditor/GridInputContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended.Input;
 using Pathfinding2D.SideView.BlazorGL.Application.Supportive.Extensions;
@@ -14,7 +15,7 @@ public class GridInputContext(Grid grid) : IContext
     private IState _currentState = new ButtonReleasedState();
 
     public MouseStateExtended MouseState { get; private set; }
-    public Cell CurrentCell { get; private set; } = Cell.None;
+    public Cell CurrentCell { get; private set; } = grid[0, 0] ?? throw new ArgumentException("grid[0, 0] is null");
     public Cell? PreviousCell { get; private set; }
     public Grid Grid { get; } = grid;
 


### PR DESCRIPTION
Let's make `Cell.Grid` mandatory to avoid a nullable property that really needn't be nullable to make code a bit more readable and less error-prone. Also, get rid of the static constructor in the `Grid` class and simplify things a bit.